### PR TITLE
Add hover states to syn buttons

### DIFF
--- a/src/Components/Form.svelte
+++ b/src/Components/Form.svelte
@@ -20,7 +20,6 @@
 		.then(data => synonyms.set(data[0].meta.syns[0]))
 		.catch(err => {
 			error.set(`There are no synonyms for ${word_value}. Please try another word.`);
-			console.log($error);
 		});
 	};
 
@@ -60,6 +59,8 @@
 	button:hover {
 		background-color: white;
 		color: #FCC1CB;
+		cursor: pointer;
+		transform: scale(1.05);
 	}
 
 </style>

--- a/src/Components/WordBox.svelte
+++ b/src/Components/WordBox.svelte
@@ -18,18 +18,39 @@
 			.then(data => synonyms.set(data[0].meta.syns[0]))
 			.catch(err => {
 				error.set(`There are no synonyms for ${e.target.value}. Please try another word.`);
-				console.log($error);
 			});
-		}
-	}
+		};
+	};
+
+	const showHover = (e) => {
+		if (e.target.id === 'button') {
+			e.target.style.background = '#FCC1CB';
+			e.target.style.color = 'white';
+		};
+		let allButtons = document.querySelectorAll('#button');
+		allButtons.forEach(button => {
+			if (button.id !== e.target.id) {
+				button.style.background = 'white';
+				button.style.color = '#545454'
+			}
+		})
+	};
 
 </script>
 
 <section className='word-box'>
 	<h1>{$word}</h1>
-	<div on:click={handleClick}>
+	<div on:click={handleClick} on:mouseover={showHover}>
 		{@html $synonyms.map(synonym =>
 			`<button
+				style="
+				font-size: 1.2vw;
+				background-color: white;
+				border: none;
+				font-weight: bold;
+				color: #545454;
+				margin-right: .5vw;
+				cursor: pointer;"
 				id='button'
 				value=${synonym}
 			>${synonym}</button>`
@@ -54,6 +75,8 @@
 		width: 40vw;
 		margin: auto;
 		margin-top: -5vw;
+		color: #545454;
 	}
+
 
 </style>


### PR DESCRIPTION
#### What's this PR do?
This PR adds hover states to the synonym buttons. 
#### Where should the reviewer start?
Look at the `WordBox.svelte` file. I could not add the hover state directly to the buttons, so I had to use a work-around on the `<div>` around them.